### PR TITLE
Improve README and ensure OpenHD recipe checks for updates

### DIFF
--- a/README
+++ b/README
@@ -1,41 +1,28 @@
-This README file contains information on the contents of the meta-openhd layer.
+meta-openhd
+===========
 
-Please see the corresponding sections below for details.
+This layer provides support for building [OpenHD](https://github.com/OpenHD/OpenHD), an open-source digital video transmission system, with the Yocto Project.
 
 Dependencies
-============
+------------
+* Compatible with the Yocto Project "scarthgap" release
+* Depends on the core `poky` layer
 
-  URI: <first dependency>
-  branch: <branch name>
+Adding the layer to your build
+------------------------------
+Clone this repository into your Yocto build tree and register the layer:
 
-  URI: <second dependency>
-  branch: <branch name>
+    bitbake-layers add-layer meta-openhd
 
-  .
-  .
-  .
+Building OpenHD
+---------------
+Once the layer is added, the OpenHD application can be built with:
 
-Patches
-=======
+    bitbake openhd
 
-Please submit any patches against the meta-openhd layer to the xxxx mailing list (xxxx@zzzz.org)
-and cc: the maintainer:
+The `openhd_git.bb` recipe tracks the latest commits from the OpenHD GitHub repository. The layer sets `BB_SRCREV_POLICY = "latest"` and the recipe uses `SRCREV = "${AUTOREV}"`, ensuring the build system checks for new upstream revisions each time the recipe is executed.
 
-Maintainer: XXX YYYYYY <xxx.yyyyyy@zzzzz.com>
+Maintainer
+----------
+OpenHD Team <https://github.com/OpenHD>
 
-Table of Contents
-=================
-
-  I. Adding the meta-openhd layer to your build
- II. Misc
-
-
-I. Adding the meta-openhd layer to your build
-=================================================
-
-Run 'bitbake-layers add-layer meta-openhd'
-
-II. Misc
-========
-
---- replace with specific information about the meta-openhd layer ---

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,3 +11,6 @@ BBFILE_PRIORITY_meta-openhd = "6"
 
 LAYERDEPENDS_meta-openhd = "core"
 LAYERSERIES_COMPAT_meta-openhd = "scarthgap"
+
+# Always check upstream repositories for the latest revisions during builds
+BB_SRCREV_POLICY = "latest"

--- a/recipes-openhd/openhd/openhd_git.bb
+++ b/recipes-openhd/openhd/openhd_git.bb
@@ -6,7 +6,10 @@ LIC_FILES_CHKSUM = "file://../LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 SRC_URI = "gitsm://github.com/openhd/OpenHD.git;protocol=https;branch=dev-release"
 
+# Track the latest revision from the OpenHD repository on each build
 SRCREV = "${AUTOREV}"
+PV = "1.0+git${SRCPV}"
+do_fetch[nostamp] = "1"
 
 S = "${WORKDIR}/git/OpenHD"
 


### PR DESCRIPTION
## Summary
- Expand README with layer usage, build steps, and explanation of automatic source updates
- Configure layer to always fetch the latest OpenHD sources
- Update OpenHD recipe to track new commits each build

## Testing
- `bitbake --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b597b900832f83319722512a2234