### PR TITLE
Add rtl88x2bu driver and enable OpenHD service

### DIFF
--- a/recipes-kernel/rtl88x2bu/rtl88x2bu_git.bb
+++ b/recipes-kernel/rtl88x2bu/rtl88x2bu_git.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Realtek RTL88x2BU WiFi driver"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7e967c391aabf5b2e4cb3b193c0b5207"
+
+inherit module
+
+SRC_URI = "gitsm://github.com/OpenHD/rtl88x2bu.git;branch=master;protocol=https"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "virtual/kernel"
+
+# Load driver automatically at boot
+KERNEL_MODULE_AUTOLOAD += "88x2bu"
+
+EXTRA_OEMAKE += "ARCH=${TARGET_ARCH} CROSS_COMPILE=${TARGET_PREFIX} KSRC=${STAGING_KERNEL_BUILDDIR}"

--- a/recipes-openhd/openhd/openhd_git.bb
+++ b/recipes-openhd/openhd/openhd_git.bb
@@ -24,8 +24,9 @@ RDEPENDS:${PN} += " \
   v4l-utils \
 "
 
-SYSTEMD_SERVICE:${PN} = "openhd.service"
-SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+# Install and enable systemd service so OpenHD starts on boot
+SYSTEMD_SERVICE = "openhd.service"
+SYSTEMD_AUTO_ENABLE = "enable"
 
 do_install:append() {
     # Install systemd service


### PR DESCRIPTION
## Summary
- Add recipe to build RTL88x2BU WiFi driver as a kernel module with autoload
- Ensure OpenHD systemd service is installed and enabled to start on boot

## Testing
- `bitbake --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6cb5b6c832f8ce7c96d56d636c2