### PR TITLE
Add RTL8812AU and RTL88x2EU kernel module recipes

### DIFF
--- a/recipes-kernel/rtl8812au/rtl8812au_git.bb
+++ b/recipes-kernel/rtl8812au/rtl8812au_git.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Realtek RTL8812AU WiFi driver"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+inherit module
+
+SRC_URI = "gitsm://github.com/OpenHD/rtl8812au.git;branch=master;protocol=https"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "virtual/kernel"
+
+KERNEL_MODULE_AUTOLOAD += "8812au"
+
+EXTRA_OEMAKE += "ARCH=arm64 CROSS_COMPILE=${TARGET_PREFIX} KSRC=${STAGING_KERNEL_BUILDDIR}"
+
+do_configure:append() {
+    sed -i 's/^CONFIG_PLATFORM_I386_PC *= *y/CONFIG_PLATFORM_I386_PC = n/' ${S}/Makefile
+    sed -i 's/^CONFIG_PLATFORM_ARM64_RPI *= *n/CONFIG_PLATFORM_ARM64_RPI = y/' ${S}/Makefile
+}
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/
+    install -m 0644 ${S}/8812au_ohd.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/
+}

--- a/recipes-kernel/rtl88x2eu/rtl88x2eu_git.bb
+++ b/recipes-kernel/rtl88x2eu/rtl88x2eu_git.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Realtek RTL88x2EU WiFi driver"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+inherit module
+
+SRC_URI = "gitsm://github.com/OpenHD/rtl88x2eu.git;branch=master;protocol=https"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "virtual/kernel"
+
+KERNEL_MODULE_AUTOLOAD += "88x2eu"
+
+EXTRA_OEMAKE += "ARCH=arm64 CROSS_COMPILE=${TARGET_PREFIX} KSRC=${STAGING_KERNEL_BUILDDIR}"
+
+do_configure:append() {
+    sed -i 's/^CONFIG_PLATFORM_I386_PC *= *y/CONFIG_PLATFORM_I386_PC = n/' ${S}/Makefile
+    sed -i 's/^CONFIG_PLATFORM_ARM64_RPI *= *n/CONFIG_PLATFORM_ARM64_RPI = y/' ${S}/Makefile
+}
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/
+    install -m 0644 ${S}/88x2eu_ohd.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/
+}


### PR DESCRIPTION
## Summary
- add RTL8812AU WiFi driver recipe with OpenHD-specific build steps
- add RTL88x2EU WiFi driver recipe mirroring 88x2BU configuration

## Testing
- `bitbake -n rtl8812au` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y bitbake` *(fails: Unable to locate package bitbake)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d3b6f024832fb0b1a50363e01fd8