### PR TITLE
rtl8812au: fix phydm include path

### DIFF
--- a/recipes-kernel/rtl8812au/rtl8812au_git.bb
+++ b/recipes-kernel/rtl8812au/rtl8812au_git.bb
@@ -18,6 +18,7 @@ EXTRA_OEMAKE += "ARCH=arm64 CROSS_COMPILE=${TARGET_PREFIX} KSRC=${STAGING_KERNEL
 do_configure:append() {
     sed -i 's/^CONFIG_PLATFORM_I386_PC *= *y/CONFIG_PLATFORM_I386_PC = n/' ${S}/Makefile
     sed -i 's/^CONFIG_PLATFORM_ARM64_RPI *= *n/CONFIG_PLATFORM_ARM64_RPI = y/' ${S}/Makefile
+    sed -i '/CONFIG_PLATFORM_ARM64_RPI/,/endif/c\\include $(src)/hal/phydm/phydm.mk' ${S}/Makefile
 }
 
 do_install() {


### PR DESCRIPTION
## Summary
- ensure rtl8812au makefile uses `$(src)` for phydm include

## Testing
- `bitbake -c patch rtl8812au` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5de71bf2c832fa3d25222e131698f