### PR TITLE
Add OpenHD WebUI recipe with systemd autostart

### DIFF
--- a/recipes-openhd/openhd-webui/openhd-webui_git.bb
+++ b/recipes-openhd/openhd-webui/openhd-webui_git.bb
@@ -1,0 +1,36 @@
+SUMMARY = "OpenHD Web user interface"
+LICENSE = "Unlicense"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d88e9e08385d2a17052dac348bde4bc1"
+
+SRC_URI = "git://github.com/OpenHD/OpenHD-WebUI.git;protocol=https;branch=master"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+inherit systemd
+
+# Build the .NET web server
+# This assumes the dotnet SDK is available in the build environment
+# and will publish a self-contained application into ${B}/publish
+
+DOTNET_TARGET ?= "linux-${TARGET_ARCH}"
+
+do_compile() {
+    dotnet publish -c Release -r ${DOTNET_TARGET} -o ${B}/publish src/OpenHdWebUi.Server/OpenHdWebUi.Server.csproj
+}
+
+do_install() {
+    install -d ${D}/usr/local/share/openhd/web-ui
+    cp -r ${B}/publish/* ${D}/usr/local/share/openhd/web-ui/
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/openhd-web-ui.service ${D}${systemd_unitdir}/system/
+}
+
+SYSTEMD_SERVICE:${PN} = "openhd-web-ui.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+FILES:${PN} += " \
+    /usr/local/share/openhd/web-ui/ \
+    ${systemd_unitdir}/system/openhd-web-ui.service \
+"

--- a/recipes-openhd/openhd/openhd_git.bb
+++ b/recipes-openhd/openhd/openhd_git.bb
@@ -22,6 +22,7 @@ RDEPENDS:${PN} += " \
   gstreamer1.0-plugins-ugly \
   gstreamer1.0-libav \
   v4l-utils \
+  openhd-webui \
 "
 
 SYSTEMD_SERVICE:${PN} = "openhd.service"


### PR DESCRIPTION
## Summary
- Add recipe for OpenHD Web user interface with systemd service enabled
- Ensure OpenHD package depends on OpenHD WebUI for automatic installation

## Testing
- ⚠️ `bitbake --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f7e70bc0832fa0895c6dbf0ec3de